### PR TITLE
fix cookie name wrong if u use proxy server

### DIFF
--- a/simple-comment-editing.php
+++ b/simple-comment-editing.php
@@ -826,9 +826,11 @@ class Simple_Comment_Editing {
 		
 		//Get hash and random security key - Stored in the style of Ajax Edit Comments
 		$comment_author_ip = $comment_date_gmt = '';
-		if ( isset( $_SERVER[ 'REMOTE_ADDR' ] ) ) {
-			$comment_author_ip = $_SERVER[ 'REMOTE_ADDR' ];	
-		}
+		if( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+                	$comment_author_ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
+	        } elseif( isset( $_SERVER['REMOTE_ADDR'] ) ) {
+        	        $comment_author_ip = $_SERVER['REMOTE_ADDR'];
+        	}	
 		$comment_date_gmt = current_time( 'Y-m-d', 1 );
 		$user_agent = substr( isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '', 0, 254 );
 		$hash = md5( $comment_author_ip . $comment_date_gmt . $this->get_user_id() . $user_agent );


### PR DESCRIPTION
first off all, nice plugin! thx for your work.

i'm using this plugin with an proxy server, so the REMOTE_ADDR is the IP from the proxy, so the cookie name gets created with Proxy IP but checking the cookie works with comment author IP which is the users real IP.

With my changes, the Plugin first looks if HTTP_X_FORWARDED_FOR is set so if proxy is used you get the users real IP, if not set anything works as before.