### PR TITLE
bypass cookie-based user verification for authenticated cookie authors

### DIFF
--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@ Plugin Name: Simple Comment Editing
 Plugin URI: http://wordpress.org/extend/plugins/simple-comment-editing/
 Description: Simple comment editing for your users.
 Author: Ronald Huereca
-Version: 2.1.11
+Version: 2.2.0
 Requires at least: 4.1
 Author URI: http://www.ronalfy.com
 Contributors: ronalfy

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: ronalfy
 Tags: ajax, comments,edit comments, edit, comment, admin
 Requires at least: 4.1
 Tested up to: 4.9
-Stable tag: 2.1.11
+Stable tag: 2.2.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Donate link: https://mediaron.com/contribute/
@@ -53,6 +53,10 @@ For advanced options, please see the <a href="https://github.com/ronalfy/simple-
 2. Textarea and Save/Cancel buttons.
 
 == Changelog ==
+
+= 2.2.0 =
+* Released 2018-10-13
+* Allow logged in users (author of the post) to bypass the cookies needed for comment editing
 
 = 2.1.11 =
 * Released 2018-05-08
@@ -261,6 +265,11 @@ For advanced options, please see the <a href="https://github.com/ronalfy/simple-
 
 = 1.0 =
 * Initial release.
+
+== Upgrade Notice ==
+
+= 2.0.0 =
+Allow logged in users (author of the post) t
 
 == Customization ==
 

--- a/simple-comment-editing.php
+++ b/simple-comment-editing.php
@@ -62,7 +62,7 @@ class Simple_Comment_Editing {
 		/* BEGIN ACTIONS */
 		//When a comment is posted
 		add_action( 'comment_post', array( $this, 'comment_posted' ),100,1 );
-		
+
 		//Loading scripts
 		add_filter( 'sce_load_scripts', array( $this, 'maybe_load_scripts' ), 5, 1 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'add_scripts' ) );
@@ -660,21 +660,43 @@ class Simple_Comment_Editing {
 	 */
 	public function can_edit( $comment_id, $post_id ) {
 		global $comment;
+
 		if ( !is_object( $comment ) ) $comment = get_comment( $comment_id, OBJECT );
+
+		if ( $comment->comment_post_ID != $post_id ) return false;
+
+		/**
+		* Filter: sce_can_edit_cookie_bypass
+		*
+		* Bypass the cookie based user verification.
+		*
+		* @since 2.0.0
+		*
+		* @param boolean Whether
+		*/
+		$cookie_bypass = apply_filters( 'sce_can_edit_cookie_bypass', false, $comment, $comment_id, $post_id );
+
+		// if we are logged in and are the comment author, bypass cookie check
+		if ( $comment->user_id != 0 && $comment->user_id == $this->get_user_id() ) {
+			$cookie_bypass = true;
+		}
+
+		if ( false === $cookie_bypass ) {
+
+			//Check to see if time has elapsed for the comment
+			$comment_timestamp = strtotime( $comment->comment_date );
+			$time_elapsed = current_time( 'timestamp', get_option( 'gmt_offset' ) ) - $comment_timestamp;
+			$minutes_elapsed = ( ( ( $time_elapsed % 604800 ) % 86400 )  % 3600 ) / 60;
 		
-		//Check to see if time has elapsed for the comment
-		$comment_timestamp = strtotime( $comment->comment_date );
-		$time_elapsed = current_time( 'timestamp', get_option( 'gmt_offset' ) ) - $comment_timestamp;
-		$minutes_elapsed = ( ( ( $time_elapsed % 604800 ) % 86400 )  % 3600 ) / 60;
-		
-		if ( ( $minutes_elapsed - $this->comment_time ) >= 0 ) return false;
-		$comment_date_gmt = date( 'Y-m-d', strtotime( $comment->comment_date_gmt ) );
-		$cookie_hash = md5( $comment->comment_author_IP . $comment_date_gmt . $comment->user_id . $comment->comment_agent );
-			
-		
-		$cookie_value = $this->get_cookie_value( 'SimpleCommentEditing' . $comment_id . $cookie_hash );
-		$comment_meta_hash = get_comment_meta( $comment_id, '_sce', true );
-		if ( $cookie_value !== $comment_meta_hash ) return false;
+			if ( ( $minutes_elapsed - $this->comment_time ) >= 0 ) return false;
+			$comment_date_gmt = date( 'Y-m-d', strtotime( $comment->comment_date_gmt ) );
+			$cookie_hash = md5( $comment->comment_author_IP . $comment_date_gmt . $comment->user_id . $comment->comment_agent );
+
+			$cookie_value = $this->get_cookie_value( 'SimpleCommentEditing' . $comment_id . $cookie_hash );
+			$comment_meta_hash = get_comment_meta( $comment_id, '_sce', true );
+			if ( $cookie_value !== $comment_meta_hash ) return false;
+
+		}
 		
 		//All is well, the person/place/thing can edit the comment
 		/**

--- a/simple-comment-editing.php
+++ b/simple-comment-editing.php
@@ -666,14 +666,17 @@ class Simple_Comment_Editing {
 		if ( $comment->comment_post_ID != $post_id ) return false;
 
 		/**
-		* Filter: sce_can_edit_cookie_bypass
-		*
-		* Bypass the cookie based user verification.
-		*
-		* @since 2.0.0
-		*
-		* @param boolean Whether
-		*/
+		 * Filter: sce_can_edit_cookie_bypass
+		 *
+		 * Bypass the cookie based user verification.
+		 *
+		 * @since 2.2.0
+		 *
+		 * @param boolean            Whether to bypass cookie authentication
+		 * @param object $comment    Comment object
+		 * @param int    $comment_id The comment ID
+		 * @param int    $post_id    The post ID of the comment
+		 */
 		$cookie_bypass = apply_filters( 'sce_can_edit_cookie_bypass', false, $comment, $comment_id, $post_id );
 
 		// if we are logged in and are the comment author, bypass cookie check
@@ -681,14 +684,14 @@ class Simple_Comment_Editing {
 			$cookie_bypass = true;
 		}
 
-		if ( false === $cookie_bypass ) {
+		//Check to see if time has elapsed for the comment
+		$comment_timestamp = strtotime( $comment->comment_date );
+		$time_elapsed = current_time( 'timestamp', get_option( 'gmt_offset' ) ) - $comment_timestamp;
+		$minutes_elapsed = ( ( ( $time_elapsed % 604800 ) % 86400 )  % 3600 ) / 60;
+		if ( ( $minutes_elapsed - $this->comment_time ) >= 0 ) return false;
 
-			//Check to see if time has elapsed for the comment
-			$comment_timestamp = strtotime( $comment->comment_date );
-			$time_elapsed = current_time( 'timestamp', get_option( 'gmt_offset' ) ) - $comment_timestamp;
-			$minutes_elapsed = ( ( ( $time_elapsed % 604800 ) % 86400 )  % 3600 ) / 60;
-		
-			if ( ( $minutes_elapsed - $this->comment_time ) >= 0 ) return false;
+		if ( false === $cookie_bypass ) {
+			// Set cookies for verification
 			$comment_date_gmt = date( 'Y-m-d', strtotime( $comment->comment_date_gmt ) );
 			$cookie_hash = md5( $comment->comment_author_IP . $comment_date_gmt . $comment->user_id . $comment->comment_agent );
 
@@ -735,8 +738,16 @@ class Simple_Comment_Editing {
 		$this->remove_security_keys();
 		
 		//Don't set a cookie if a comment is posted via Ajax
+		$cookie_bypass = apply_filters( 'sce_can_edit_cookie_bypass', false, $comment, $comment_id, $post_id );
+		
+		// if we are logged in and are the comment author, bypass cookie check
+		if ( $comment->user_id != 0 && $comment->user_id == $this->get_user_id() ) {
+			$cookie_bypass = true;
+		}
 		if ( ! defined( 'DOING_AJAX' ) && ! defined( 'EPOCH_API' ) ) {
-			 $this->generate_cookie_data( $post_id, $comment_id, 'setcookie' );
+			if( false === $cookie_bypass ) {
+				$this->generate_cookie_data( $post_id, $comment_id, 'setcookie' );
+			}
 		}
 		
 		

--- a/simple-comment-editing.php
+++ b/simple-comment-editing.php
@@ -659,9 +659,10 @@ class Simple_Comment_Editing {
 	 * @return bool true if can edit, false if not
 	 */
 	public function can_edit( $comment_id, $post_id ) {
-		global $comment;
+		global $comment, $post;
 
 		if ( !is_object( $comment ) ) $comment = get_comment( $comment_id, OBJECT );
+		if ( !is_object( $post ) ) $post = get_post( $post_id, OBJECT );
 
 		if ( $comment->comment_post_ID != $post_id ) return false;
 
@@ -680,7 +681,8 @@ class Simple_Comment_Editing {
 		$cookie_bypass = apply_filters( 'sce_can_edit_cookie_bypass', false, $comment, $comment_id, $post_id );
 
 		// if we are logged in and are the comment author, bypass cookie check
-		if ( $comment->user_id != 0 && $comment->user_id == $this->get_user_id() ) {
+		$user_id = $this->get_user_id();
+		if ( $post->post_author == $user_id || $comment->user_id == $user_id ) {
 			$cookie_bypass = true;
 		}
 


### PR DESCRIPTION
This automatically bypasses the cookie check if the current user is the comment author (making the decision of "can_edit" controlled exclusively by the sce_can_edit filter), and adds a filter to allow someone to bypass the cookie check based on their own custom logic.