### PR TITLE
Fix the Webpack5 deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "use-async-resource": "^2.2.2",
     "webpack": "^5.87.0",
     "webpack-cli": "^4.6.0",
-    "webpack-fix-style-only-entries": "^0.6.1"
+    "webpack-remove-empty-scripts": "^1.0.4"
   },
   "dependencies": {
     "sass": "^1.34.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require( 'path' );
-const FixStyleOnlyEntriesPlugin = require( 'webpack-fix-style-only-entries' );
+const RemoveEmptyScripts = require('webpack-remove-empty-scripts');
 const MiniCssExtractPlugin = require( 'mini-css-extract-plugin' );
 
 module.exports = ( env ) => {
@@ -35,7 +35,7 @@ module.exports = ( env ) => {
 				],
 			},
 			devtool: 'source-map',
-			plugins: [ new FixStyleOnlyEntriesPlugin(), new MiniCssExtractPlugin() ],
+			plugins: [ new RemoveEmptyScripts(), new MiniCssExtractPlugin() ],
 		},
 		{
 			mode: env.mode,
@@ -83,7 +83,7 @@ module.exports = ( env ) => {
 					},
 				],
 			},
-			plugins: [ new FixStyleOnlyEntriesPlugin(), new MiniCssExtractPlugin() ],
+			plugins: [ new RemoveEmptyScripts(), new MiniCssExtractPlugin() ],
 		},
 	];
 };


### PR DESCRIPTION
Hello,

this project uses the outdated [webpack-fix-style-only-entries](https://github.com/fqborges/webpack-fix-style-only-entries) plugin that is incompatible with `Webpack 5`.

Using `npm run build` appear the deprecation warnings:
```
webpack-fix-style-only-entries:
(node:18462) [DEP_WEBPACK_CHUNK_ENTRY_MODULE] DeprecationWarning: Chunk.entryModule: Use new ChunkGraph API
(node:18462) [DEP_WEBPACK_MODULE_INDEX] DeprecationWarning: Module.index: Use new ModuleGraph API
(node:18462) [DEP_WEBPACK_DEPRECATION_ARRAY_TO_SET] DeprecationWarning: chunk.files was changed from Array to Set (using Array method 'filter' is deprecated)
```

The author of the [webpack-fix-style-only-entries](https://github.com/fqborges/webpack-fix-style-only-entries) plugin recommends using the [webpack-remove-empty-scripts](https://github.com/webdiscus/webpack-remove-empty-scripts) plugin for Webpack 5.

This PR just replaces the outdated plugin with the actual version.